### PR TITLE
Use recommended template naming instead of deprecated one

### DIFF
--- a/src/Resources/config/routing/admin.yaml
+++ b/src/Resources/config/routing/admin.yaml
@@ -2,7 +2,7 @@ setono_sylius_callout_admin_callout:
     resource: |
         section: admin
         alias: setono_sylius_callout.callout
-        templates: SyliusAdminBundle:Crud
+        templates: '@SyliusAdmin/Crud'
         permission: true
         redirect: update
         grid: setono_sylius_callout_admin_callout


### PR DESCRIPTION
Fixes #31 