### PR TITLE
Fixing a wrong template name in grid

### DIFF
--- a/src/Resources/config/grids/setono_sylius_callout_admin_callout.yaml
+++ b/src/Resources/config/grids/setono_sylius_callout_admin_callout.yaml
@@ -18,7 +18,7 @@ sylius_grid:
                     label: setono_sylius_callout.ui.enabled
                     sortable: ~
                     options:
-                        template: SyliusUiBundle:Grid/Field:enabled.html.twig
+                        template: '@SyliusUi/Grid/Field/enabled.html.twig'
                 updatedAt:
                     type: datetime
                     label: setono_sylius_callout.ui.updated_at


### PR DESCRIPTION
Use new syntax instead of old one