### PR TITLE
Allow setter with null

### DIFF
--- a/src/Model/CalloutTranslation.php
+++ b/src/Model/CalloutTranslation.php
@@ -24,7 +24,7 @@ class CalloutTranslation extends AbstractTranslation implements CalloutTranslati
         return $this->text;
     }
 
-    public function setText(string $text): void
+    public function setText(?string $text): void
     {
         $this->text = $text;
     }

--- a/src/Model/CalloutTranslationInterface.php
+++ b/src/Model/CalloutTranslationInterface.php
@@ -11,5 +11,5 @@ interface CalloutTranslationInterface extends ResourceInterface, TranslationInte
 {
     public function getText(): ?string;
 
-    public function setText(string $text): void;
+    public function setText(?string $text): void;
 }


### PR DESCRIPTION
It sometimes is necessary to include the form with null data. It should be up to validator to warn about wrong data. Not the setter. Especially since it throws a 500