### PR TITLE
Follow-up on PR #55

### DIFF
--- a/src/Resources/config/app/grids.yaml
+++ b/src/Resources/config/app/grids.yaml
@@ -1,8 +1,8 @@
 imports:
     - { resource: "@SetonoSyliusCalloutPlugin/Resources/config/grids/setono_sylius_callout_admin_callout.yaml" }
-      
+
 sylius_grid:
     templates:
         action:
             setono_callout_default: "@SetonoSyliusCalloutPlugin/Admin/Grid/Action/setono_callout_default.html.twig"
-            callouts_product_list: "@SetonoSyliusCalloutPlugin/Admin/Grid/Action/calloutsProductList.html.twig"
+            setono_callout_product_list : "@SetonoSyliusCalloutPlugin/Admin/Grid/Action/calloutsProductList.html.twig"

--- a/src/Resources/config/grids/setono_sylius_callout_admin_callout.yaml
+++ b/src/Resources/config/grids/setono_sylius_callout_admin_callout.yaml
@@ -71,8 +71,8 @@ sylius_grid:
                 item:
                     update:
                         type: update
-                    callouts_product_list:
-                        type: callouts_product_list
+                    setono_callout_product_list:
+                        type: setono_callout_product_list
                         label: setono_sylius_callout.ui.callouts_product_list
                     delete:
                         type: delete


### PR DESCRIPTION
Rename callouts_product_list grid action to setono_callout_product_list for consistency with other plugin actions.

Follow-up on #55.