### PR TITLE
Allow callouts without rules in fixtures

### DIFF
--- a/src/Fixture/CalloutFixture.php
+++ b/src/Fixture/CalloutFixture.php
@@ -11,7 +11,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 class CalloutFixture extends AbstractResourceFixture
 {
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getName(): string
     {
@@ -19,7 +19,7 @@ class CalloutFixture extends AbstractResourceFixture
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function configureResourceNode(ArrayNodeDefinition $resourceNode): void
     {

--- a/src/Fixture/Factory/CalloutExampleFactory.php
+++ b/src/Fixture/Factory/CalloutExampleFactory.php
@@ -128,7 +128,7 @@ class CalloutExampleFactory extends AbstractExampleFactory
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function configureOptions(OptionsResolver $resolver): void
     {

--- a/src/Fixture/Factory/CalloutExampleFactory.php
+++ b/src/Fixture/Factory/CalloutExampleFactory.php
@@ -162,14 +162,8 @@ class CalloutExampleFactory extends AbstractExampleFactory
             ->setAllowedTypes('channels', ['array'])
             ->setNormalizer('channels', LazyOption::findBy($this->channelRepository, 'code'))
 
-            ->setDefined('rules')
-            ->setNormalizer('rules', function (Options $options, array $rules): array {
-                if ($rules === []) {
-                    return [[]];
-                }
-
-                return $rules;
-            })
+            ->setDefault('rules', [])
+            ->setAllowedTypes('rules', ['array'])
 
             ->setDefault('enabled', true)
             ->setAllowedTypes('enabled', ['boolean'])

--- a/src/Fixture/Factory/CalloutRuleExampleFactory.php
+++ b/src/Fixture/Factory/CalloutRuleExampleFactory.php
@@ -32,7 +32,7 @@ class CalloutRuleExampleFactory extends AbstractExampleFactory implements Exampl
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function create(array $options = []): CalloutRuleInterface
     {
@@ -47,7 +47,7 @@ class CalloutRuleExampleFactory extends AbstractExampleFactory implements Exampl
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function configureOptions(OptionsResolver $resolver): void
     {

--- a/src/Resources/config/app/fixtures.yaml
+++ b/src/Resources/config/app/fixtures.yaml
@@ -21,6 +21,10 @@ sylius_fixtures:
                 setono_sylius_callout:
                     options:
                         custom:
+                            callout_without_rules:
+                                code: 'callout_without_rules'
+                                name: 'Callout without rules'
+
                             callout_today_only:
                                 name: "Today only"
                                 code: "today-only"

--- a/tests/Behat/Context/Ui/Shop/ProductContext.php
+++ b/tests/Behat/Context/Ui/Shop/ProductContext.php
@@ -35,7 +35,7 @@ final class ProductContext implements Context
     {
         /** @var CalloutInterface $callout */
         $callout = $this->calloutRepository->findOneBy([
-            'code' => StringInflector::nameToCode($name)
+            'code' => StringInflector::nameToCode($name),
         ]);
 
         Assert::same($this->indexPage->countProductsWithCallouts(strip_tags($callout->getText())), $count);

--- a/tests/Fixture/Factory/CalloutExampleFactoryTest.php
+++ b/tests/Fixture/Factory/CalloutExampleFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Setono\SyliusCalloutPlugin\Fixture\Factory;
+
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusCalloutPlugin\Factory\CalloutRuleFactory;
+use Setono\SyliusCalloutPlugin\Fixture\Factory\CalloutExampleFactory;
+use Setono\SyliusCalloutPlugin\Fixture\Factory\CalloutRuleExampleFactory;
+use Setono\SyliusCalloutPlugin\Model\Callout;
+use Setono\SyliusCalloutPlugin\Model\CalloutRule;
+use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\Channel;
+use Sylius\Component\Locale\Model\Locale;
+use Sylius\Component\Resource\Factory\Factory;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+class CalloutExampleFactoryTest extends TestCase
+{
+    private ExampleFactoryInterface $calloutExampleFactory;
+
+    /** @test */
+    public function create_callout_without_rules(): void
+    {
+        $callout = $this->calloutExampleFactory->create(['name' => 'Callout without rules', 'rules' => []]);
+
+        self::assertEquals('Callout without rules', $callout->getName());
+        self::assertCount(0, $callout->getRules());
+    }
+
+    protected function setUp(): void
+    {
+        $calloutRuleFactory = new CalloutRuleFactory(new Factory(CalloutRule::class));
+        $calloutRuleExampleFactory = new CalloutRuleExampleFactory($calloutRuleFactory);
+        $calloutFactory = new Factory(Callout::class);
+        $calloutManager = $this->createMock(ObjectManager::class);
+        $channelRepository = $this->createMock(ChannelRepositoryInterface::class);
+
+        $channel = new Channel();
+        $channel->setCode('default');
+
+        $channelRepository
+            ->expects(self::once())
+            ->method('findAll')
+            ->willReturn([$channel]);
+
+        $localeRepository = $this->createMock(RepositoryInterface::class);
+
+        $locale = new Locale();
+        $locale->setCode('en_US');
+
+        $localeRepository
+            ->expects(self::once())
+            ->method('findAll')
+            ->willReturn([$locale]);
+
+        $this->calloutExampleFactory = new CalloutExampleFactory(
+            $calloutFactory,
+            $calloutManager,
+            $calloutRuleExampleFactory,
+            $channelRepository,
+            $localeRepository,
+        );
+    }
+}


### PR DESCRIPTION
Adding callouts without rules in fixtures throws an error, because it tries to access an index of an empty array.
This happens because the `rules` normalizer converts `[]` to `[[]]`.
I couldn't find why this normalizer is needed, so I removed it.